### PR TITLE
[DEV] Main 페이지 기본 구성

### DIFF
--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,11 +1,13 @@
 import MainHeader from "./MainHeader";
 import MainUnitRank from "./MainUnitRank";
+import MainPopularLicense from "./MainPopularLicense"
 
 const Main = () => {
   return (
     <div>
       <MainHeader />
       <MainUnitRank />
+      <MainPopularLicense />
     </div>
   );
 }

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,8 +1,12 @@
 import MainHeader from "./MainHeader";
+import MainUnitRank from "./MainUnitRank";
 
 const Main = () => {
   return (
-    <MainHeader />
+    <div>
+      <MainHeader />
+      <MainUnitRank />
+    </div>
   );
 }
 

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,0 +1,9 @@
+import MainHeader from "./MainHeader";
+
+const Main = () => {
+  return (
+    <MainHeader />
+  );
+}
+
+export default Main;

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -5,12 +5,12 @@ import Info from "./MainInfo"
 
 const Main = () => {
   return (
-    <div>
+    <>
       <Header />
       <UnitRank />
       <PopularLicense />
       <Info />
-    </div>
+    </>
   );
 }
 

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,13 +1,15 @@
-import MainHeader from "./MainHeader";
-import MainUnitRank from "./MainUnitRank";
-import MainPopularLicense from "./MainPopularLicense"
+import Header from "./MainHeader";
+import UnitRank from "./MainUnitRank";
+import PopularLicense from "./MainPopularLicense"
+import Info from "./MainInfo"
 
 const Main = () => {
   return (
     <div>
-      <MainHeader />
-      <MainUnitRank />
-      <MainPopularLicense />
+      <Header />
+      <UnitRank />
+      <PopularLicense />
+      <Info />
     </div>
   );
 }

--- a/src/pages/main/MainHeader.tsx
+++ b/src/pages/main/MainHeader.tsx
@@ -1,0 +1,18 @@
+import Image from "next/image";
+
+const Header = () => {
+return (
+    <div className="relative w-fill h-96">
+      <img src="https://picsum.photos/200" className="object-cover w-full h-96"/>
+      {/* Image 컴포넌트로 변경 예정 */}
+      <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 flex flex-col items-center w-full">
+        <h1 className="text-white text-4xl text-center font-bold drop-shadow-md">국군 정예화의 초석</h1>
+        <h1 className="text-orange-600 text-4xl text-center font-bold mt-1.5 drop-shadow-md">밀리센스</h1>
+        <p className="text-white text-sm text-center mt-8 ml-10 mr-10 drop-shadow-md">밀리센스는 기술을 통한 국군 정예화를 위해 탄생한 부대 별 자격증 취득 랭킹 커뮤니티입니다.</p>
+        <p className="text-white text-sm text-center mt-8 ml-10 mr-10 drop-shadow-md">2022년 한 해, <span className="text-orange-600 font-medium underline">5196개의 자격증</span>이 국군 정예화에 도움이 되고 있습니다.</p>
+      </div>
+    </div>
+  );
+};
+
+export default Header;

--- a/src/pages/main/MainInfo.tsx
+++ b/src/pages/main/MainInfo.tsx
@@ -1,0 +1,22 @@
+const Info = () => {
+  return (
+    <div className="flex flex-col w-full pr-5 pl-5">
+      <h1 className="text-2xl font-bold text-orange-600 mt-10">랭킹을 높여나가는 재미</h1>
+      <p className="text-sm">장병 개인이 취득한 국가 기술 자격증에 점수, MP(Milisence Point) 를 부여하고, 장병들의 점수들은 모여 부대의 MP가 됩니다.</p>
+      <br></br>
+      <p className="text-sm">밀리센스 랭킹을 통해 소속된 부대에 대한 자부심 함양과 국가 기술 자격증 취득에 동기를 부여하고자 합니다.</p>
+
+      <h1 className="text-2xl font-bold text-orange-600 mt-10">내 병과, 어떤 자격증이 필요할까?</h1>
+      <p className="text-sm">밀리센스에서는 병과 별로 취득했을 때 도움이 될 국가 기술 자격증을 분류하여 장병 개개인에게 자격증을 추천합니다.</p>
+      <br></br>
+      <p className="text-sm">내 병과에 맞는 국가 기술 자격증을 취득하여 부대 전투력 향상에 도움을 줄 수 있다면 좋겠죠.</p>
+
+      <h1 className="text-2xl font-bold text-orange-600 mt-10">교재비가 부담된다면?</h1>
+      <p className="text-sm">밀리센스는 사용자가 취득하고 싶은 국가 기술 자격증을 공부할 수 있는 서적을 국방대 전자도서관 자료 기반으로 추천합니다.</p>
+      <br></br>
+      <p className="text-sm">교재, 구매하지 말고 전자도서관에서 이용하세요.</p>
+    </div>
+  );
+}
+
+export default Info;

--- a/src/pages/main/MainPopularLicense.tsx
+++ b/src/pages/main/MainPopularLicense.tsx
@@ -1,6 +1,6 @@
 const PopularLicense = () => {
     return (
-      <div className="flex flex-col w-full pt-10 pr-4 pl-4">
+      <div className="flex flex-col w-full pt-10 pr-5 pl-5">
         <p className="text-sm">전우들은 어떤 자격증을 취득했을까?</p>
         <h1 className="text-2xl font-bold text-orange-600">군 내 인기 국가 기술 자격증</h1>
 

--- a/src/pages/main/MainPopularLicense.tsx
+++ b/src/pages/main/MainPopularLicense.tsx
@@ -1,0 +1,16 @@
+const PopularLicense = () => {
+    return (
+      <div className="flex flex-col w-full pt-10 pr-4 pl-4">
+        <p className="text-sm">전우들은 어떤 자격증을 취득했을까?</p>
+        <h1 className="text-2xl font-bold text-orange-600">군 내 인기 국가 기술 자격증</h1>
+
+        <div className="w-full bg-orange-100 rounded-lg drop-shadow mt-1.5 mb-1.5 pt-1.5 pb-1.5 text-lime-800 text-center text-xl font-bold">지게차운전기능사</div>
+        <div className="w-full bg-orange-100 rounded-lg drop-shadow mt-1.5 mb-1.5 pt-1.5 pb-1.5 text-lime-800 text-center text-xl font-bold">정보처리기능사</div>
+        <div className="w-full bg-orange-100 rounded-lg drop-shadow mt-1.5 mb-1.5 pt-1.5 pb-1.5 text-lime-800 text-center text-xl font-bold">자동차정비기능사</div>
+
+        <p className="text-sm text-orange-600 text-center underline mt-1">인기가 많은 국가 기술 자격증을 추천해드려요.</p>
+      </div>
+    );
+  }
+
+  export default PopularLicense;

--- a/src/pages/main/MainUnitRank.tsx
+++ b/src/pages/main/MainUnitRank.tsx
@@ -1,0 +1,41 @@
+interface RankCardProps {
+  rank: number;
+  unitName: string;
+  mp: number
+}
+
+const RankCard = (props: RankCardProps) => {
+  return (
+    <div className="flex flex-row justify-evenly items-center w-full bg-orange-100 rounded-lg drop-shadow mt-1.5 mb-1.5 pt-2 pb-2">
+      {
+        props.rank === 1 ? 
+        <h1 className="basis-1/5 text-3xl text-yellow-300 text-center font-bold">1</h1> :
+        props.rank === 2 ?
+        <h1 className="basis-1/5 text-3xl text-slate-500 text-center font-bold">2</h1> :
+        props.rank === 3 ?
+        <h1 className="basis-1/5 text-3xl text-amber-800 text-center font-bold">3</h1> :
+        <h1 className="basis-1/5 text-3xl font-bold">{props.rank}</h1>
+      }
+      <h1 className="basis-3/5 text-3xl text-lime-800 text-center font-semibold">{props.unitName}</h1>
+      <div className="basis-1/5 flex flex-col text-right mr-2">
+        <p className="text-sm text-orange-600">mp</p>
+        <p className="font-bold">{props.mp}</p>
+      </div>
+    </div>
+  );
+}
+
+const UnitRank = () => {
+  return (
+    <div className="flex flex-col w-full pt-10 pr-4 pl-4">
+      <p className="text-sm">우리 부대 더 강하게!</p>
+      <h1 className="text-2xl font-bold text-orange-600">우리 부대 자격증 랭킹</h1>
+      <RankCard rank={1} unitName="제8기동사단" mp={1200} />
+      <RankCard rank={2} unitName="방공관제사령부" mp={1000} />
+      <RankCard rank={3} unitName="제3보병사단" mp={900} />
+      <p className="text-sm text-orange-600 text-center underline mt-1">상위 3개 부대를 확인 할 수 있어요.</p>
+    </div>
+  );
+}
+
+export default UnitRank;

--- a/src/pages/main/MainUnitRank.tsx
+++ b/src/pages/main/MainUnitRank.tsx
@@ -27,7 +27,7 @@ const RankCard = (props: RankCardProps) => {
 
 const UnitRank = () => {
   return (
-    <div className="flex flex-col w-full pt-10 pr-4 pl-4">
+    <div className="flex flex-col w-full pt-10 pr-5 pl-5">
       <p className="text-sm">우리 부대 더 강하게!</p>
       <h1 className="text-2xl font-bold text-orange-600">우리 부대 자격증 랭킹</h1>
       <RankCard rank={1} unitName="제8기동사단" mp={1200} />

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./Main";


### PR DESCRIPTION
## Summary
Main 페이지 기본 레이아웃을 구성했습니니다.
## Description
- Main 페이지 헤더 컴포넌트 생성
- Main 페이지에서 부대 순위를 나타내는 MainUnitRank 컴포넌트 생성
- Main 페이지에서 인기 자격증 목록을 나타내는 MainPopularLicense 컴포넌트 생성
- Main 페이지에서 사이트를 설명하는 MainInfo 컴포넌트 생성
## ScreenShots
<img width="341" alt="Screenshot 2023-07-03 at 5 04 07 PM" src="https://github.com/DefCon-Apps/Military_License/assets/10252712/4519e7d8-5515-4fc3-9f29-9728bc8f5635">
<img width="342" alt="Screenshot 2023-07-03 at 5 04 25 PM" src="https://github.com/DefCon-Apps/Military_License/assets/10252712/bf38c45c-1f8a-428f-8f5e-702d4ef7e51e">
