### PR TITLE
[DEV_FE] 자격증 리스트 페이지 기본 구성 

### DIFF
--- a/src/pages/LicenseList/LicenseList.tsx
+++ b/src/pages/LicenseList/LicenseList.tsx
@@ -1,0 +1,20 @@
+import ListPage from "../ListPage";
+import ListAll from "./LicenseListAll";
+import ListByClass from "./LicenseListByClass";
+import ListByType from "./LicenseListByType";
+import ListInOrder from "./LicenseListInOrder";
+
+const LicenseList = () => {
+  return (
+    <ListPage
+      title="국가 기술 자격증 추천"
+      tabs={[
+        {name: "전체 자격증", component: <ListAll />},
+        {name: "병과별 추천", component: <ListByClass />},
+        {name: "분야별 추천", component: <ListByType />},
+        {name: "전체 취득순", component: <ListInOrder />},
+      ]} />
+  );
+}
+
+export default LicenseList;

--- a/src/pages/LicenseList/LicenseListAll.tsx
+++ b/src/pages/LicenseList/LicenseListAll.tsx
@@ -1,0 +1,22 @@
+import Search from "./LicenseSearch"
+import ListTable from "../ListTable";
+
+const LicenseListAll = () => {
+  const dummyArray: React.ReactNode[][] = [];
+  for (let i = 0; i < 25; i++) {
+    dummyArray.push([<p key={i} className="text-xs text-lime-800">굴삭기운전기능사</p>, <p className="text-xs text-lime-800">146. 건설기계 운전</p>, <p className="text-xs text-lime-800">한국산업인력공단</p>])
+  }
+
+  return (
+    <>
+      <Search />
+      <div className="grow flex flex-col w-full overflow-y-scroll">
+        <ListTable
+          tableHead={["자격증", "증분류", "시행처"]}
+          tableData={dummyArray} />
+      </div>
+    </>
+  );
+}
+
+export default LicenseListAll;

--- a/src/pages/LicenseList/LicenseListByClass.tsx
+++ b/src/pages/LicenseList/LicenseListByClass.tsx
@@ -1,0 +1,32 @@
+import Search from "./LicenseSearch"
+import ListTable from "../ListTable";
+
+const CLASSES = ["보병", "기갑", "포병", "방공", "정보", "공병", "정보통신", "항공", "화생방", "병기", "병참", "수송", "인사", "군사경찰", "재정", "공보정훈", "군수", "의무", "법무", "군종", "함정", "조함", "보급", "항공통제", "방공포병", "기상"];
+
+const LicenseListByClass = () => {
+  const dummyArray: React.ReactNode[][] = [];
+  for (let i = 0; i < 25; i++) {
+    dummyArray.push([<p key={i} className="text-xs text-lime-800">굴삭기운전기능사</p>, <p className="text-xs text-lime-800">146. 건설기계 운전</p>, <p className="text-xs text-lime-800">한국산업인력공단</p>])
+  }
+
+  return (
+    <>
+      <div className="flex flex-row pt-3 pb-1">
+        <span className="text-lime-800 font-bold">나의 병과 (주특기) : </span>
+        <span className="text-orange-600 pl-1 pr-2">공병</span>
+        <select className="text-xs bg-orange-100 rounded-lg">
+          <option>다른 병과 선택</option>
+          {CLASSES.map((className, index) => <option key={index}>{className}</option>)}
+        </select>
+      </div>
+      <Search />
+      <div className="grow flex flex-col w-full overflow-y-scroll">
+        <ListTable
+          tableHead={["자격증", "증분류", "시행처"]}
+          tableData={dummyArray} />
+      </div>
+    </>
+  );
+}
+
+export default LicenseListByClass;

--- a/src/pages/LicenseList/LicenseListByType.tsx
+++ b/src/pages/LicenseList/LicenseListByType.tsx
@@ -1,0 +1,34 @@
+import Search from "./LicenseSearch"
+import ListTable from "../ListTable";
+import { useState } from "react";
+
+const LicenseListByType = () => {
+  const dummyArray: React.ReactNode[][] = [];
+  for (let i = 0; i < 25; i++) {
+    dummyArray.push([<p key={i} className="text-xs text-lime-800">굴삭기운전기능사</p>, <p className="text-xs text-lime-800">146. 건설기계 운전</p>, <p className="text-xs text-lime-800">한국산업인력공단</p>])
+  }
+
+  const [selectedType, setType] = useState("증분류 선택");
+  const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => setType(e.currentTarget.value);
+
+  return (
+    <>
+      <div className="flex flex-row pt-3 pb-1">
+        <span className="text-lime-800 font-bold">증분류 : </span>
+        <span className="text-orange-600 pl-1 pr-2">{selectedType}</span>
+        <select className="text-xs bg-orange-100 rounded-lg" onChange={onSelectChange}>
+          <option>증분류 선택</option>
+          <option>146. 건설기계 운전</option>
+        </select>
+      </div>
+      <Search />
+      <div className="grow flex flex-col w-full overflow-y-scroll">
+        <ListTable
+          tableHead={["자격증", "증분류", "시행처"]}
+          tableData={dummyArray} />
+      </div>
+    </>
+  );
+}
+
+export default LicenseListByType;

--- a/src/pages/LicenseList/LicenseListInOrder.tsx
+++ b/src/pages/LicenseList/LicenseListInOrder.tsx
@@ -1,0 +1,22 @@
+import Search from "./LicenseSearch"
+import ListTable from "../ListTable";
+
+const LicenseListInOrder = () => {
+  const dummyArray: React.ReactNode[][] = [];
+  for (let i = 0; i < 25; i++) {
+    dummyArray.push([<p key={i} className="text-xs text-lime-800">굴삭기운전기능사</p>, <p className="text-xs text-lime-800">146. 건설기계 운전</p>, <p className="text-xs text-lime-800">한국산업인력공단</p>])
+  }
+
+  return (
+    <>
+      <Search />
+      <div className="grow flex flex-col w-full overflow-y-scroll">
+        <ListTable
+          tableHead={["자격증", "증분류", "시행처"]}
+          tableData={dummyArray} />
+      </div>
+    </>
+  );
+}
+
+export default LicenseListInOrder;

--- a/src/pages/LicenseList/LicenseSearch.tsx
+++ b/src/pages/LicenseList/LicenseSearch.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 const LicenseSearch = () => {
   const [text, setText] = useState("");
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.target.value);
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.currentTarget.value);
   const search = () => console.log(`search value : ${text}`);
 
   return (

--- a/src/pages/LicenseList/LicenseSearch.tsx
+++ b/src/pages/LicenseList/LicenseSearch.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+const LicenseSearch = () => {
+  const [text, setText] = useState("");
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.target.value);
+  const search = () => console.log(`search value : ${text}`);
+
+  return (
+    <div className="flex flex-row w-full bg-orange-100 rounded-lg drop-shadow mt-1 mb-2.5 pt-1 pr-2 pb-1 pl-2">
+      <input className="grow bg-transparent text-sm" type="search" placeholder="자격증 검색" onChange={onChange} value={text}></input>
+      <button onClick={search}>
+        <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M14.796 12.9685L11.8749 10.0478C11.743 9.91602 11.5643 9.84279 11.3768 9.84279H10.8992C11.7079 8.80871 12.1884 7.50806 12.1884 6.09316C12.1884 2.72727 9.46065 0 6.0942 0C2.72774 0 0 2.72727 0 6.09316C0 9.45904 2.72774 12.1863 6.0942 12.1863C7.50934 12.1863 8.81021 11.7059 9.84447 10.8974V11.3749C9.84447 11.5623 9.91772 11.741 10.0496 11.8729L12.9707 14.7935C13.2461 15.0688 13.6914 15.0688 13.9639 14.7935L14.7931 13.9645C15.0685 13.6891 15.0685 13.2438 14.796 12.9685ZM6.0942 9.84279C4.02276 9.84279 2.34392 8.16717 2.34392 6.09316C2.34392 4.02207 4.01982 2.34352 6.0942 2.34352C8.16564 2.34352 9.84447 4.01914 9.84447 6.09316C9.84447 8.16424 8.16857 9.84279 6.0942 9.84279Z" fill="#41644A"/>
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export default LicenseSearch;

--- a/src/pages/LicenseList/index.tsx
+++ b/src/pages/LicenseList/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./LicenseList";

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -1,7 +1,7 @@
 /*
-const tab1 = {name: "전체 자격증", component: <Component1 />}
-const tab2 = {name: "병과별 추천", component: <Component2 />}
-const tab3 = {name: "분야별 추천", component: <Component3 />}
+const tab1 = {name: "전체 자격증", component: <Component1 key={...} />}
+const tab2 = {name: "병과별 추천", component: <Component2 key={...} />}
+const tab3 = {name: "분야별 추천", component: <Component3 key={...} />}
 
 ...
 
@@ -31,7 +31,7 @@ const ListPage = (props: Props) => {
     <div className="flex flex-col w-full mt-16 pr-5 pl-5">
       <h1 className="text-orange-600 text-3xl font-bold drop-shadow-md">{props.title}</h1>
       <div className="flex flex-row w-full mt-2 mb-3">
-        {props.tabs.map((tab, index) => <button className={index === currentTabNumber ? classNameSelected + classNameTab : classNameTab} onClick={() => setTabNumber(index)}>{tab.name}</button>)}
+        {props.tabs.map((tab, index) => <button key={index} className={index === currentTabNumber ? classNameSelected + classNameTab : classNameTab} onClick={() => setTabNumber(index)}>{tab.name}</button>)}
       </div>
       {props.tabs[currentTabNumber].component}
     </div>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -1,0 +1,41 @@
+/*
+const tab1 = {name: "전체 자격증", component: <Component1 />}
+const tab2 = {name: "병과별 추천", component: <Component2 />}
+const tab3 = {name: "분야별 추천", component: <Component3 />}
+
+...
+
+  <ListPage 
+    title="국가 기술 자격증 추천"
+    tabs={[tab1, tab2, tab3]} />
+*/
+
+import { useState } from "react";
+
+interface Tab {
+  name: string;
+  component: React.ReactNode;
+}
+
+interface Props {
+  title: string;
+  tabs: Tab[];
+}
+
+const ListPage = (props: Props) => {
+  const [currentTabNumber, setTabNumber] = useState(0);
+  const classNameTab = "text-lime-800 font-semibold mr-3 ";
+  const classNameSelected = "underline underline-offset-4 decoration-4 ";
+
+  return (
+    <div className="flex flex-col w-full mt-16 pr-5 pl-5">
+      <h1 className="text-orange-600 text-3xl font-bold drop-shadow-md">{props.title}</h1>
+      <div className="flex flex-row w-full mt-2 mb-3">
+        {props.tabs.map((tab, index) => <button className={index === currentTabNumber ? classNameSelected + classNameTab : classNameTab} onClick={() => setTabNumber(index)}>{tab.name}</button>)}
+      </div>
+      {props.tabs[currentTabNumber].component}
+    </div>
+  );
+}
+
+export default ListPage;

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -28,7 +28,7 @@ const ListPage = (props: Props) => {
   const classNameSelected = "underline underline-offset-4 decoration-4 ";
 
   return (
-    <div className="flex flex-col w-full mt-16 pr-5 pl-5">
+    <div className="flex flex-col w-full h-screen pt-16 pr-5 pl-5">
       <h1 className="text-orange-600 text-3xl font-bold drop-shadow-md">{props.title}</h1>
       <div className="flex flex-row w-full mt-2 mb-3">
         {props.tabs.map((tab, index) => <button key={index} className={index === currentTabNumber ? classNameSelected + classNameTab : classNameTab} onClick={() => setTabNumber(index)}>{tab.name}</button>)}

--- a/src/pages/ListTable.tsx
+++ b/src/pages/ListTable.tsx
@@ -1,0 +1,36 @@
+/*
+<ListTable 
+  tableHead={['랭킹', '계급', '이름', '획득MP', '취득 자격증 수']}
+  tableData={[
+    [<p className="...">1</p>, <img src="..." />, "김푸앙", 120, 8],
+    [<p className="...">2</p>, <img src="..." />, "김대림", 110, 7],
+    [<p className="...">3</p>, <img src="..." />, "박안양", 100, 7],
+    ...
+  ]} />
+*/
+
+import { useEffect, useState } from "react";
+
+interface Props {
+  tableHead: string[];
+  tableData: Array<Array<React.ReactNode>>;
+}
+
+const ListTable = (props: Props) => {
+  const [isMounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []); // Prevent hydration error
+
+  return (isMounted && 
+  <table className="w-full text-center">
+      <thead className="text-xs text-orange-600 border-b border-orange-600">
+        {props.tableHead.map((thData) => <th className="font-medium">{thData}</th>)}
+      </thead>
+      <tbody>
+        {props.tableData.map((row) => <tr>{row.map((col) => <td className="border-b border-orange-600 pt-1.5 pb-1.5">{col}</td>)}</tr>)}
+      </tbody>
+    </table>
+  );
+}
+
+export default ListTable;

--- a/src/pages/ListTable.tsx
+++ b/src/pages/ListTable.tsx
@@ -2,9 +2,9 @@
 <ListTable 
   tableHead={['랭킹', '계급', '이름', '획득MP', '취득 자격증 수']}
   tableData={[
-    [<p className="...">1</p>, <img src="..." />, "김푸앙", 120, 8],
-    [<p className="...">2</p>, <img src="..." />, "김대림", 110, 7],
-    [<p className="...">3</p>, <img src="..." />, "박안양", 100, 7],
+    [<p key={...} className="...">1</p>, <img key={...} src="..." />, "김푸앙", 120, 8],
+    [<p key={...} className="...">2</p>, <img key={...} src="..." />, "김대림", 110, 7],
+    [<p key={...} className="...">3</p>, <img key={...} src="..." />, "박안양", 100, 7],
     ...
   ]} />
 */
@@ -24,10 +24,10 @@ const ListTable = (props: Props) => {
   return (isMounted && 
   <table className="w-full text-center">
       <thead className="text-xs text-orange-600 border-b border-orange-600">
-        {props.tableHead.map((thData) => <th className="font-medium">{thData}</th>)}
+        {props.tableHead.map((thData, index) => <th key={index} className="font-medium">{thData}</th>)}
       </thead>
       <tbody>
-        {props.tableData.map((row) => <tr>{row.map((col) => <td className="border-b border-orange-600 pt-1.5 pb-1.5">{col}</td>)}</tr>)}
+        {props.tableData.map((row, index) => <tr key={index}>{row.map((col, index) => <td key={index} className="border-b border-orange-600 pt-1.5 pb-1.5">{col}</td>)}</tr>)}
       </tbody>
     </table>
   );

--- a/src/pages/ListTable.tsx
+++ b/src/pages/ListTable.tsx
@@ -23,13 +23,13 @@ const ListTable = (props: Props) => {
 
   return (isMounted && 
   <table className="w-full text-center">
-      <thead className="text-xs text-orange-600 border-b border-orange-600">
-        {props.tableHead.map((thData, index) => <th key={index} className="font-medium">{thData}</th>)}
-      </thead>
-      <tbody>
-        {props.tableData.map((row, index) => <tr key={index}>{row.map((col, index) => <td key={index} className="border-b border-orange-600 pt-1.5 pb-1.5">{col}</td>)}</tr>)}
-      </tbody>
-    </table>
+    <thead className="text-xs text-orange-600 border-b border-orange-600">
+      {props.tableHead.map((thData, index) => <th key={index} className="font-medium">{thData}</th>)}
+    </thead>
+    <tbody>
+      {props.tableData.map((row, index) => <tr key={index}>{row.map((col, index) => <td key={index} className="border-b border-orange-600 pt-1.5 pb-1.5">{col}</td>)}</tr>)}
+    </tbody>
+  </table>
   );
 }
 


### PR DESCRIPTION
## Summary
자격증 리스트 페이지의 기본 레이아웃을 구성했습니다
## Description
### 재사용 가능한 2개 컴포넌트 생성
@HarenKei 이거 한 번 봐주십쇼
- 탭으로 분류해서 페이지를 조회하는 ListPage 컴포넌트 생성
```tsx
// 컴포넌트 사용 예시
const tab1 = {name: "전체 자격증", component: <Component1 />}
const tab2 = {name: "병과별 추천", component: <Component2 />}
const tab3 = {name: "분야별 추천", component: <Component3 />}
...
  <ListPage 
    title="국가 기술 자격증 추천"
    tabs={[tab1, tab2, tab3]} />
```
- 테이블 형태로 목록을 나타내는 ListTable 컴포넌트 생성
```tsx
// 컴포넌트 사용 예시
<ListTable 
  tableHead={['랭킹', '계급', '이름', '획득MP', '취득 자격증 수']}
  tableData={[
    [<p className="...">1</p>, <img src="..." />, "김푸앙", 120, 8],
    [<p className="...">2</p>, <img src="..." />, "김대림", 110, 7],
    [<p className="...">3</p>, <img src="..." />, "박안양", 100, 7],
    ...
  ]} />
```
### Etc
- 검색어를 입력하는 LicenseSearch 컴포넌트 생성
- 전체 자격증 목록을 조회하는 LicenseListAll 컴포넌트 생성
- 병과별 추천 자격증 목록을 조회하는 LicenseListByClass 컴포넌트 생성
- 분야별 추천 자격증 목록을 조회하는 LicenseListByType 컴포넌트 생성
- 전체 취득순으로 자격증 목록을 조회하는 LicenseListInOrder 컴포넌트 생성
## ScreenShots
<img width="339" alt="Screenshot 2023-07-04 at 10 47 36 PM" src="https://github.com/DefCon-Apps/Military_License/assets/10252712/9653c4ed-b2b8-4908-bfbf-2cdb7ebfdc64">
<img width="339" alt="Screenshot 2023-07-04 at 10 48 10 PM" src="https://github.com/DefCon-Apps/Military_License/assets/10252712/551fdac5-25ab-465d-8ce2-603d72408b9f">
<img width="339" alt="Screenshot 2023-07-04 at 10 48 36 PM" src="https://github.com/DefCon-Apps/Military_License/assets/10252712/927915c2-b5bb-47ad-8259-68ec10bd06e2">
<img width="338" alt="Screenshot 2023-07-04 at 10 49 01 PM" src="https://github.com/DefCon-Apps/Military_License/assets/10252712/dd9117e3-4ef9-4503-acdb-1f0858d1dbe0">
