### PR TITLE
[DEV_BE] 자격증 취득순 정렬 API 구성

### DIFF
--- a/src/pages/api/license/getListByCount.ts
+++ b/src/pages/api/license/getListByCount.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getLicenseListByCount, initFirebase } from "@/utils/FirebaseUtil";
+import { API_DATA } from "@/utils/DataClass";
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<API_DATA>
+) {
+    initFirebase();
+    res.send(await getLicenseListByCount());
+}

--- a/src/utils/DataClass.ts
+++ b/src/utils/DataClass.ts
@@ -5,7 +5,7 @@ export interface API_DATA{
 }
 
 export interface LIST_DATA{
-    data: Array<BOOK_DATA | LICENSE_LIST_DATA | RANK_BRANCH_DATA | RANK_UNIT_DATA | RANK_USER_DATA>
+    data: Array<BOOK_DATA | LICENSE_LIST_DATA | LICENSE_LIST_COUNT_DATA | RANK_BRANCH_DATA | RANK_UNIT_DATA | RANK_USER_DATA>
 }
 
 export interface BOOK_DATA{
@@ -29,6 +29,21 @@ export interface LICENSE_DATA{
 }
 
 export interface LICENSE_LIST_DATA{
+    strGualgbcd: string,
+    strGualgbnm: string,
+    strJmfldnm: string,
+    strMdobligfldcd: string,
+    strMdobligfldnm: string,
+    strObligfldcd: string,
+    strObligfldnm: string,
+    strSeriescd: string,
+    strSeriesnm: string
+}
+
+export interface LICENSE_LIST_COUNT_DATA{
+    count: number,
+    content: string,
+    schedule: Array<string>,
     strGualgbcd: string,
     strGualgbnm: string,
     strJmfldnm: string,

--- a/src/utils/DataClass.ts
+++ b/src/utils/DataClass.ts
@@ -42,8 +42,6 @@ export interface LICENSE_LIST_DATA{
 
 export interface LICENSE_LIST_COUNT_DATA{
     count: number,
-    content: string,
-    schedule: Array<string>,
     strGualgbcd: string,
     strGualgbnm: string,
     strJmfldnm: string,

--- a/src/utils/DataClass.ts
+++ b/src/utils/DataClass.ts
@@ -42,6 +42,7 @@ export interface LICENSE_LIST_DATA{
 
 export interface LICENSE_LIST_COUNT_DATA{
     count: number,
+    licenseCode: string,
     strGualgbcd: string,
     strGualgbnm: string,
     strJmfldnm: string,

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -181,6 +181,16 @@ export const getLicenseListByCode = async (code: string) => {
     return RESULT_DATA
 }
 
+export const getLicenseListByCount = async () => {
+    const RESULT_DATA: API_DATA = {
+        RESULT_CODE: 0,
+        RESULT_MSG: "Ready",
+        RESULT_DATA: {}
+    }
+
+    return RESULT_DATA
+}
+
 export const getMilLibraryBookList = async (keyword: string) => {
     const RESULT_DATA: API_DATA = {
         RESULT_CODE: 0,

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -231,6 +231,7 @@ export const getLicenseListByCount = async () => {
             listLicense.forEach((curLicense) => {
                 if(curLicense.licenseCode == licenseCode){
                     curLicense.count++;
+                    return;
                 }
             });
         })


### PR DESCRIPTION
## Summary
자격증 리스트를 취득순으로 정렬하여 반환하는 API를 구현하였습니다.

## Description
- 지난 #11 에서 누락된 취득순 정렬 API를 구현하였습니다.
- `getListAll` 함수와 유사하나, `장병 국가기술자격 취득 정보` 공공데이터에서 제공한 통계를 기반으로 취득순에 따라 정렬하여 결과를 반환합니다.
- `/api/license/getListByCount`의 형태로 GET 요청을 전송하면, 해당 종목코드에 대한 자격증의 상세 정보를 다음과 같은 형식으로 반환합니다.
```json
{
  "RESULT_CODE": 200,
  "RESULT_MSG": "Success",
  "RESULT_DATA": {
    "data":[
      {
        "count": 2157,
        "licenseCode": "7875",
        "strGualgbcd": "T",
        "strGualgbnm": "국가기술자격",
        "strJmfldnm": "지게차운전기능사",
        "strMdobligfldcd": "146",
        "strMdobligfldnm": "건설기계운전",
        "strObligfldcd": "14",
        "strObligfldnm": "건설",
        "strSeriescd": "04",
        "strSeriesnm": "기능사"
      },
    ]
  }
}
```