### PR TITLE
[DEV_BE] 부대목록 API 구성

### DIFF
--- a/src/pages/api/unit/getUnitList/[type].ts
+++ b/src/pages/api/unit/getUnitList/[type].ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getUnitList, initFirebase } from "@/utils/FirebaseUtil";
+import { API_DATA } from "@/utils/DataClass";
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<API_DATA>
+) {
+    const { type } = req.query;
+
+    initFirebase();
+    res.send(await getUnitList(type!.toString()));
+}

--- a/src/utils/DataClass.ts
+++ b/src/utils/DataClass.ts
@@ -5,7 +5,8 @@ export interface API_DATA{
 }
 
 export interface LIST_DATA{
-    data: Array<BOOK_DATA | LICENSE_LIST_DATA | LICENSE_LIST_COUNT_DATA | RANK_BRANCH_DATA | RANK_UNIT_DATA | RANK_USER_DATA>
+    data: Array<BOOK_DATA | LICENSE_LIST_DATA | LICENSE_LIST_COUNT_DATA
+        | RANK_BRANCH_DATA | RANK_UNIT_DATA | RANK_USER_DATA | string>
 }
 
 export interface BOOK_DATA{

--- a/src/utils/DataClass.ts
+++ b/src/utils/DataClass.ts
@@ -6,7 +6,7 @@ export interface API_DATA{
 
 export interface LIST_DATA{
     data: Array<BOOK_DATA | LICENSE_LIST_DATA | LICENSE_LIST_COUNT_DATA
-        | RANK_BRANCH_DATA | RANK_UNIT_DATA | RANK_USER_DATA | string>
+        | RANK_BRANCH_DATA | RANK_UNIT_DATA | RANK_USER_DATA>
 }
 
 export interface BOOK_DATA{

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -432,6 +432,16 @@ export const getRankByUnit = async () => {
     return RESULT_DATA
 }
 
+export const getUnitList = async (type: string) => {
+    const RESULT_DATA: API_DATA = {
+        RESULT_CODE: 0,
+        RESULT_MSG: "Ready",
+        RESULT_DATA: {}
+    }
+
+    return RESULT_DATA;
+}
+
 export const getUserData = async (uid: string) => {
     return getFirebaseDB("User", uid);
 }

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -433,13 +433,7 @@ export const getRankByUnit = async () => {
 }
 
 export const getUnitList = async (type: string) => {
-    const RESULT_DATA: API_DATA = {
-        RESULT_CODE: 0,
-        RESULT_MSG: "Ready",
-        RESULT_DATA: {}
-    }
-
-    return RESULT_DATA;
+    return getFirebaseDB("Unit", type);
 }
 
 export const getUserData = async (uid: string) => {


### PR DESCRIPTION
## Summary
Back-End의 부대목록 관련 API를 구현하였습니다.

## Description
- 기존 도서검색 API 구현 시 제작한 `FirebaseUtil`을 활용하였습니다.
- 부대별 타입에 따른 부대목록 조회 API를 구성하였습니다. `/api/unit/getUnitList/군종`의 형태로 `GET` 요청을 전송하면, 해당 군종에 대한 부대 목록을 다음과 같은 형식으로 반환합니다. 군종 코드는 `army`, `airforce`, `navy`로 입력합니다.
```json
{
  "RESULT_CODE": 200,
  "RESULT_MSG": "Success",
  "RESULT_DATA": {
    "list":[
      {
        "mp":0,
        "name":"공군본부"
      },
      {
        "mp":0,
        "name":"제35비행전대"
      },
      {
        "mp":0,
        "name":"제53특수비행전대"
      },
      {
        "mp":0,
        "name":"정보체계관리단"
      },
      ...
    ]
  }
}
```