### PR TITLE
[FIX] 자격증 API 개선

### DIFF
--- a/src/utils/DataClass.ts
+++ b/src/utils/DataClass.ts
@@ -17,6 +17,7 @@ export interface BOOK_DATA{
 
 export interface LICENSE_DATA{
     content: string,
+    licenseCode: string,
     schedule: Array<string>,
     strGualgbcd: string,
     strGualgbnm: string,
@@ -30,6 +31,7 @@ export interface LICENSE_DATA{
 }
 
 export interface LICENSE_LIST_DATA{
+    licenseCode: string,
     strGualgbcd: string,
     strGualgbnm: string,
     strJmfldnm: string,

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -121,6 +121,7 @@ export const getLicenseListAll = async () => {
 
         fbDocument.forEach((curDoc) => {
             let tmpData = {
+                licenseCode: curDoc.id,
                 strGualgbcd: curDoc.get("strGualgbcd"),
                 strGualgbnm: curDoc.get("strGualgbnm"),
                 strJmfldnm: curDoc.get("strJmfldnm"),
@@ -165,6 +166,7 @@ export const getLicenseListByCode = async (code: string) => {
         fbDocument.forEach((curDoc) => {
             if (curDoc.get("strObligfldcd") == code) {
                 let tmpData = {
+                    licenseCode: curDoc.id,
                     strGualgbcd: curDoc.get("strGualgbcd"),
                     strGualgbnm: curDoc.get("strGualgbnm"),
                     strJmfldnm: curDoc.get("strJmfldnm"),


### PR DESCRIPTION
## Summary
자격증 목록 관련 API를 개선하였습니다.

## Description
- 자격증 목록을 조건에 따라 조회하는 API에서, 각 자격증 객체에 ID값이 누락되는 문제가 있어 해결하였습니다. 기존과 동일하게 접근하되, `licenseCode`의 이름으로 각 자격증의 ID값에 접근할 수 있습니다.